### PR TITLE
[ng-dev] Async test helpers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,7 @@
 # To finish AsyncMethodController
 
-- write docs
-- test that it's exposed in the public API
 - test all the typing
+- write docs
 - scour the branch for outstanding TODO comments
 - get `nth()` into `micro-dash`
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,3 @@
-# To finish AsyncMethodController
-
-- scour the branch for outstanding TODO comments
-
----
-
 - landing page to link to all API docs
 - coveralls
   - help may be here, to combine multiple coverage runs into one report: https://github.com/angular/angular-cli/issues/11268

--- a/TODO.md
+++ b/TODO.md
@@ -1,14 +1,15 @@
 # To finish AsyncMethodController
-- passing `ctx` to the controller to trigger change detection
-- expectNone()
-- match(<array of args>)
+
 - TestCall.call (at least needs a test still)
 - verify()
-- get `nth()` into `micro-dash`
+- passing `ctx` to the controller to trigger change detection
+- write docs
+- test that it's exposed in the public API
 - test all the typing
 - scour the branch for outstanding TODO comments
-- test that it's exposed in the public API
+- get `nth()` into `micro-dash`
 
+---
 
 - landing page to link to all API docs
 - coveralls

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 # To finish AsyncMethodController
 
-- TestCall.call (at least needs a test still)
 - verify()
 - passing `ctx` to the controller to trigger change detection
 - write docs

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 # To finish AsyncMethodController
 
-- write docs
 - scour the branch for outstanding TODO comments
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,7 @@
 # To finish AsyncMethodController
 
-- test all the typing
 - write docs
 - scour the branch for outstanding TODO comments
-- get `nth()` into `micro-dash`
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,16 @@
+# To finish AsyncMethodController
+- passing `ctx` to the controller to trigger change detection
+- expectNone()
+- match(<array of args>)
+- TestCall.call (at least needs a test still)
+- verify()
+- get `nth()` into `micro-dash`
+- test all the typing
+- scour the branch for outstanding TODO comments
+- test that it's exposed in the public API
+
+
 - landing page to link to all API docs
 - coveralls
   - help may be here, to combine multiple coverage runs into one report: https://github.com/angular/angular-cli/issues/11268
-- see if typedoc can support that "lib" mode that would eliminate the need for @hidden yet
+- Watch for when typedoc can support that "lib" mode that would eliminate the need for @hidden

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 # To finish AsyncMethodController
 
-- verify()
 - passing `ctx` to the controller to trigger change detection
 - write docs
 - test that it's exposed in the public API

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 # To finish AsyncMethodController
 
-- passing `ctx` to the controller to trigger change detection
 - write docs
 - test that it's exposed in the public API
 - test all the typing

--- a/projects/integration/src/app/api-tests/ng-dev.spec.ts
+++ b/projects/integration/src/app/api-tests/ng-dev.spec.ts
@@ -1,6 +1,8 @@
 import {
   AngularContext,
+  AsyncMethodController,
   ComponentContext,
+  TestCall,
   createSpyObject,
   expectCallsAndReset,
   expectSingleCallAndReset,
@@ -15,8 +17,16 @@ describe('ng-dev', () => {
     expect(AngularContext).toBeDefined();
   });
 
+  it('has AsyncMethodController', () => {
+    expect(AsyncMethodController).toBeDefined();
+  });
+
   it('has ComponentContext', () => {
     expect(ComponentContext).toBeDefined();
+  });
+
+  it('has TestCall', () => {
+    expect(TestCall).toBeDefined();
   });
 
   it('has createSpyObject()', () => {

--- a/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
@@ -26,19 +26,6 @@ describe('AsyncMethodController', () => {
       expect(match.callInfo.args[0]).toEqual('value 2');
     });
 
-    it('removes the matching call from future matching', () => {
-      const controller = new AsyncMethodController(
-        navigator.clipboard,
-        'writeText',
-      );
-      navigator.clipboard.writeText('value 1');
-      navigator.clipboard.writeText('value 2');
-
-      controller.expectOne((call) => call.args[0] === 'value 2');
-
-      expect(controller.match(() => true).length).toBe(1);
-    });
-
     describe('error message', () => {
       it('throws an error when there is no match', () => {
         const controller = new AsyncMethodController(
@@ -171,18 +158,17 @@ describe('AsyncMethodController', () => {
       );
     });
 
-    it('does not remove the matching calls from future matching', () => {
+    it('remove the matching calls from future matching', () => {
       const controller = new AsyncMethodController(
         navigator.clipboard,
-        'readText',
+        'writeText',
       );
-      navigator.clipboard.readText();
-      navigator.clipboard.readText();
+      navigator.clipboard.writeText('value 1');
+      navigator.clipboard.writeText('value 2');
 
-      controller.match(() => true);
-      const matchesOnSecondTry = controller.match(() => true);
+      controller.match((call) => call.args[0] === 'value 2');
 
-      expect(matchesOnSecondTry.length).toEqual(2);
+      expect(controller.match(() => true).length).toBe(1);
     });
 
     it('returns an empty array when there have been no calls', () => {

--- a/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
@@ -1,3 +1,4 @@
+import { AngularContext } from '../test-context';
 import { AsyncMethodController } from './async-method-controller';
 
 describe('AsyncMethodController', () => {
@@ -308,6 +309,33 @@ describe('AsyncMethodController', () => {
       expect(() => {
         controller.expectOne((call) => call.args[0] !== 'value 2');
       }).toThrowMatching((error: Error) => error.message.includes('found 2'));
+    });
+  });
+
+  describe('examples from the docs', () => {
+    it('can paste', () => {
+      const clipboard = navigator.clipboard;
+      const ctx = new AngularContext();
+
+      // mock the browser API for pasting
+      const controller = new AsyncMethodController(clipboard, 'readText', {
+        ctx,
+      });
+      ctx.run(() => {
+        // BEGIN production code that copies to the clipboard
+        let pastedText: string;
+        clipboard.readText().then((text) => {
+          pastedText = text;
+        });
+        // END production code that copies to the clipboard
+
+        // mock the behavior when the user denies access to the clipboard
+        controller.expectOne([]).flush('mock clipboard contents');
+
+        // BEGIN expect the correct results after a successful copy
+        expect(pastedText!).toBe('mock clipboard contents');
+        // END expect the correct results after a successful copy
+      });
     });
   });
 });

--- a/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
@@ -1,0 +1,56 @@
+import { AsyncMethodController } from './async-method-controller';
+
+describe('AsyncMethodController', () => {
+  describe('.match()', () => {
+    it('finds matching method calls', () => {
+      const asyncStub = new AsyncMethodController(
+        navigator.clipboard,
+        'writeText',
+      );
+      navigator.clipboard.writeText('value 1');
+      navigator.clipboard.writeText('value 2');
+      navigator.clipboard.writeText('value 3');
+
+      const matches = asyncStub.match((call) => call.args[0] !== 'value 2');
+
+      expect(matches.map((match) => match.callInfo.args[0])).toEqual(
+        jasmine.arrayWithExactContents(['value 1', 'value 3']),
+      );
+    });
+
+    it('does not remove the matching calls from future matching', () => {
+      const asyncStub = new AsyncMethodController(
+        navigator.clipboard,
+        'readText',
+      );
+      navigator.clipboard.readText();
+      navigator.clipboard.readText();
+
+      asyncStub.match(() => true);
+      const matchesOnSecondTry = asyncStub.match(() => true);
+
+      expect(matchesOnSecondTry.length).toEqual(2);
+    });
+
+    it('returns an empty array when there have been no calls', () => {
+      const asyncStub = new AsyncMethodController(
+        navigator.clipboard,
+        'readText',
+      );
+      const matches = asyncStub.match(() => false);
+      expect(matches).toEqual([]);
+    });
+
+    it('can gracefully handle when no calls match', () => {
+      const asyncStub = new AsyncMethodController(
+        navigator.clipboard,
+        'readText',
+      );
+      navigator.clipboard.readText();
+
+      const matches = asyncStub.match(() => false);
+
+      expect(matches).toEqual([]);
+    });
+  });
+});

--- a/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
@@ -12,88 +12,6 @@ describe('AsyncMethodController', () => {
     });
   });
 
-  describe('.match()', () => {
-    it('finds matching method calls', () => {
-      const controller = new AsyncMethodController(
-        navigator.clipboard,
-        'writeText',
-      );
-      navigator.clipboard.writeText('value 1');
-      navigator.clipboard.writeText('value 2');
-      navigator.clipboard.writeText('value 3');
-
-      const matches = controller.match((call) => call.args[0] !== 'value 2');
-
-      expect(matches.map((match) => match.callInfo.args[0])).toEqual(
-        jasmine.arrayWithExactContents(['value 1', 'value 3']),
-      );
-    });
-
-    it('accepts an array of arguments to match against', () => {
-      const controller = new AsyncMethodController(
-        navigator.clipboard,
-        'writeText',
-      );
-      navigator.clipboard.writeText('value 1');
-      navigator.clipboard.writeText('value 2');
-      navigator.clipboard.writeText('value 1');
-
-      const matches = controller.match(['value 1']);
-
-      expect(matches.map((match) => match.callInfo.args[0])).toEqual(
-        jasmine.arrayWithExactContents(['value 1', 'value 1']),
-      );
-    });
-
-    it('uses deep equality matching for the arguments shorthand', () => {
-      const controller = new AsyncMethodController(window, 'fetch');
-      fetch('a fake url', { method: 'GET' });
-      fetch('a fake url', { method: 'POST' });
-      fetch('a fake url', { method: 'GET' });
-
-      const matches = controller.match(['a fake url', { method: 'GET' }]);
-
-      expect(matches.map((match) => match.callInfo.args[1])).toEqual(
-        jasmine.arrayWithExactContents([{ method: 'GET' }, { method: 'GET' }]),
-      );
-    });
-
-    it('does not remove the matching calls from future matching', () => {
-      const controller = new AsyncMethodController(
-        navigator.clipboard,
-        'readText',
-      );
-      navigator.clipboard.readText();
-      navigator.clipboard.readText();
-
-      controller.match(() => true);
-      const matchesOnSecondTry = controller.match(() => true);
-
-      expect(matchesOnSecondTry.length).toEqual(2);
-    });
-
-    it('returns an empty array when there have been no calls', () => {
-      const controller = new AsyncMethodController(
-        navigator.clipboard,
-        'readText',
-      );
-      const matches = controller.match(() => false);
-      expect(matches).toEqual([]);
-    });
-
-    it('can gracefully handle when no calls match', () => {
-      const controller = new AsyncMethodController(
-        navigator.clipboard,
-        'readText',
-      );
-      navigator.clipboard.readText();
-
-      const matches = controller.match(() => false);
-
-      expect(matches).toEqual([]);
-    });
-  });
-
   describe('.expectOne()', () => {
     it('finds a matching method call', () => {
       const controller = new AsyncMethodController(
@@ -204,6 +122,88 @@ describe('AsyncMethodController', () => {
       expect(() => {
         controller.expectNone(['value 2']);
       }).toThrowMatching((error: Error) => error.message.includes('found 1'));
+    });
+  });
+
+  describe('.match()', () => {
+    it('finds matching method calls', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'writeText',
+      );
+      navigator.clipboard.writeText('value 1');
+      navigator.clipboard.writeText('value 2');
+      navigator.clipboard.writeText('value 3');
+
+      const matches = controller.match((call) => call.args[0] !== 'value 2');
+
+      expect(matches.map((match) => match.callInfo.args[0])).toEqual(
+        jasmine.arrayWithExactContents(['value 1', 'value 3']),
+      );
+    });
+
+    it('accepts an array of arguments to match against', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'writeText',
+      );
+      navigator.clipboard.writeText('value 1');
+      navigator.clipboard.writeText('value 2');
+      navigator.clipboard.writeText('value 1');
+
+      const matches = controller.match(['value 1']);
+
+      expect(matches.map((match) => match.callInfo.args[0])).toEqual(
+        jasmine.arrayWithExactContents(['value 1', 'value 1']),
+      );
+    });
+
+    it('uses deep equality matching for the arguments shorthand', () => {
+      const controller = new AsyncMethodController(window, 'fetch');
+      fetch('a fake url', { method: 'GET' });
+      fetch('a fake url', { method: 'POST' });
+      fetch('a fake url', { method: 'GET' });
+
+      const matches = controller.match(['a fake url', { method: 'GET' }]);
+
+      expect(matches.map((match) => match.callInfo.args[1])).toEqual(
+        jasmine.arrayWithExactContents([{ method: 'GET' }, { method: 'GET' }]),
+      );
+    });
+
+    it('does not remove the matching calls from future matching', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'readText',
+      );
+      navigator.clipboard.readText();
+      navigator.clipboard.readText();
+
+      controller.match(() => true);
+      const matchesOnSecondTry = controller.match(() => true);
+
+      expect(matchesOnSecondTry.length).toEqual(2);
+    });
+
+    it('returns an empty array when there have been no calls', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'readText',
+      );
+      const matches = controller.match(() => false);
+      expect(matches).toEqual([]);
+    });
+
+    it('can gracefully handle when no calls match', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'readText',
+      );
+      navigator.clipboard.readText();
+
+      const matches = controller.match(() => false);
+
+      expect(matches).toEqual([]);
     });
   });
 

--- a/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
@@ -64,4 +64,104 @@ describe('AsyncMethodController', () => {
       expect(matches).toEqual([]);
     });
   });
+
+  describe('.expectOne', () => {
+    it('finds a matching method call', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'writeText',
+      );
+      navigator.clipboard.writeText('value 1');
+      navigator.clipboard.writeText('value 2');
+
+      const match = controller.expectOne((call) => call.args[0] === 'value 2');
+
+      expect(match.callInfo.args[0]).toEqual('value 2');
+    });
+
+    it('removes the matching call from future matching', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'writeText',
+      );
+      navigator.clipboard.writeText('value 1');
+      navigator.clipboard.writeText('value 2');
+
+      controller.expectOne((call) => call.args[0] === 'value 2');
+
+      expect(controller.match(() => true).length).toBe(1);
+    });
+
+    it('throws an error when there is no match', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'readText',
+      );
+      navigator.clipboard.readText();
+
+      expect(() => {
+        controller.expectOne(() => false);
+      }).toThrowError(
+        'Expected one matching request for criterion "Match by function: ", found none',
+      );
+    });
+
+    it('throws an error when there have been no calls', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'readText',
+      );
+
+      expect(() => {
+        controller.expectOne(() => true);
+      }).toThrowError(
+        'Expected one matching request for criterion "Match by function: ", found none',
+      );
+    });
+
+    it('throws an error when there is more than one match', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'readText',
+      );
+      navigator.clipboard.readText();
+      navigator.clipboard.readText();
+
+      expect(() => {
+        controller.expectOne(() => true);
+      }).toThrowError(
+        'Expected one matching request for criterion "Match by function: ", found 2',
+      );
+    });
+
+    it('includes the given description when throwing an error', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'readText',
+      );
+
+      expect(() => {
+        controller.expectOne(() => true, 'show this');
+      }).toThrowError(
+        'Expected one matching request for criterion "show this", found none',
+      );
+    });
+
+    it('includes the name of the match function when throwing an error, when no description is provided', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'readText',
+      );
+
+      expect(() => {
+        controller.expectOne(nofindy);
+      }).toThrowError(
+        'Expected one matching request for criterion "Match by function: nofindy", found none',
+      );
+
+      function nofindy(): boolean {
+        return false;
+      }
+    });
+  });
 });

--- a/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
@@ -29,6 +29,35 @@ describe('AsyncMethodController', () => {
       );
     });
 
+    it('accepts an array of arguments to match against', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'writeText',
+      );
+      navigator.clipboard.writeText('value 1');
+      navigator.clipboard.writeText('value 2');
+      navigator.clipboard.writeText('value 1');
+
+      const matches = controller.match(['value 1']);
+
+      expect(matches.map((match) => match.callInfo.args[0])).toEqual(
+        jasmine.arrayWithExactContents(['value 1', 'value 1']),
+      );
+    });
+
+    it('uses deep equality matching for the arguments shorthand', () => {
+      const controller = new AsyncMethodController(window, 'fetch');
+      fetch('a fake url', { method: 'GET' });
+      fetch('a fake url', { method: 'POST' });
+      fetch('a fake url', { method: 'GET' });
+
+      const matches = controller.match(['a fake url', { method: 'GET' }]);
+
+      expect(matches.map((match) => match.callInfo.args[1])).toEqual(
+        jasmine.arrayWithExactContents([{ method: 'GET' }, { method: 'GET' }]),
+      );
+    });
+
     it('does not remove the matching calls from future matching', () => {
       const controller = new AsyncMethodController(
         navigator.clipboard,
@@ -65,7 +94,7 @@ describe('AsyncMethodController', () => {
     });
   });
 
-  describe('.expectOne', () => {
+  describe('.expectOne()', () => {
     it('finds a matching method call', () => {
       const controller = new AsyncMethodController(
         navigator.clipboard,
@@ -92,48 +121,93 @@ describe('AsyncMethodController', () => {
       expect(controller.match(() => true).length).toBe(1);
     });
 
-    it('throws an error when there is no match', () => {
+    describe('error message', () => {
+      it('throws an error when there is no match', () => {
+        const controller = new AsyncMethodController(
+          navigator.clipboard,
+          'readText',
+        );
+        navigator.clipboard.readText();
+
+        expect(() => {
+          controller.expectOne(() => false);
+        }).toThrowError(
+          'Expected one matching request(s) for criterion "Match by function: ", found 0',
+        );
+      });
+
+      it('throws an error when there have been no calls', () => {
+        const controller = new AsyncMethodController(
+          navigator.clipboard,
+          'readText',
+        );
+
+        expect(() => {
+          controller.expectOne(() => true);
+        }).toThrowError(
+          'Expected one matching request(s) for criterion "Match by function: ", found 0',
+        );
+      });
+
+      it('throws an error when there is more than one match', () => {
+        const controller = new AsyncMethodController(
+          navigator.clipboard,
+          'readText',
+        );
+        navigator.clipboard.readText();
+        navigator.clipboard.readText();
+
+        expect(() => {
+          controller.expectOne(() => true);
+        }).toThrowError(
+          'Expected one matching request(s) for criterion "Match by function: ", found 2',
+        );
+      });
+    });
+  });
+
+  describe('.expectNone()', () => {
+    it('throws an error if any call matches', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'writeText',
+      );
+      navigator.clipboard.writeText('value 1');
+      navigator.clipboard.writeText('value 2');
+
+      expect(() => {
+        controller.expectNone((call) => call.args[0] === 'value 2');
+      }).toThrowError(
+        'Expected zero matching request(s) for criterion "Match by function: ", found 1',
+      );
+    });
+
+    it('does not throw an error when no call matches', () => {
       const controller = new AsyncMethodController(
         navigator.clipboard,
         'readText',
       );
-      navigator.clipboard.readText();
 
       expect(() => {
-        controller.expectOne(() => false);
-      }).toThrowError(
-        'Expected one matching request for criterion "Match by function: ", found none',
-      );
+        controller.expectNone(() => false);
+      }).not.toThrowError();
     });
 
-    it('throws an error when there have been no calls', () => {
+    it('accepts an array of arguments to match against', () => {
       const controller = new AsyncMethodController(
         navigator.clipboard,
-        'readText',
+        'writeText',
       );
+      navigator.clipboard.writeText('value 1');
+      navigator.clipboard.writeText('value 2');
 
       expect(() => {
-        controller.expectOne(() => true);
-      }).toThrowError(
-        'Expected one matching request for criterion "Match by function: ", found none',
-      );
+        controller.expectNone(['value 2']);
+      }).toThrowMatching((error: Error) => error.message.includes('found 1'));
     });
+  });
 
-    it('throws an error when there is more than one match', () => {
-      const controller = new AsyncMethodController(
-        navigator.clipboard,
-        'readText',
-      );
-      navigator.clipboard.readText();
-      navigator.clipboard.readText();
-
-      expect(() => {
-        controller.expectOne(() => true);
-      }).toThrowError(
-        'Expected one matching request for criterion "Match by function: ", found 2',
-      );
-    });
-
+  describe('.buildErrorMessage()', () => {
     it('includes the given description when throwing an error', () => {
       const controller = new AsyncMethodController(
         navigator.clipboard,
@@ -142,8 +216,8 @@ describe('AsyncMethodController', () => {
 
       expect(() => {
         controller.expectOne(() => true, 'show this');
-      }).toThrowError(
-        'Expected one matching request for criterion "show this", found none',
+      }).toThrowMatching((error: Error) =>
+        error.message.includes('for criterion "show this"'),
       );
     });
 
@@ -155,13 +229,39 @@ describe('AsyncMethodController', () => {
 
       expect(() => {
         controller.expectOne(nofindy);
-      }).toThrowError(
-        'Expected one matching request for criterion "Match by function: nofindy", found none',
+      }).toThrowMatching((error: Error) =>
+        error.message.includes('criterion "Match by function: nofindy"'),
       );
 
       function nofindy(): boolean {
         return false;
       }
+    });
+
+    it('formats the error message nicely when using the arguments shorthand', () => {
+      const controller = new AsyncMethodController(window, 'fetch');
+
+      expect(() => {
+        controller.expectOne(['some url', { method: 'GET' }]);
+      }).toThrowMatching((error: Error) =>
+        error.message.includes(
+          'for criterion "Match by arguments: ["some url",{"method":"GET"}]"',
+        ),
+      );
+    });
+
+    it('includes the number of matches found', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'writeText',
+      );
+      navigator.clipboard.writeText('value 1');
+      navigator.clipboard.writeText('value 2');
+      navigator.clipboard.writeText('value 3');
+
+      expect(() => {
+        controller.expectOne((call) => call.args[0] !== 'value 2');
+      }).toThrowMatching((error: Error) => error.message.includes('found 2'));
     });
   });
 });

--- a/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
@@ -1,9 +1,20 @@
 import { AsyncMethodController } from './async-method-controller';
 
 describe('AsyncMethodController', () => {
+  describe('constructor', () => {
+    it('allows the controlled method to be called immediately', () => {
+      // tslint:disable-next-line:no-unused-expression
+      new AsyncMethodController(navigator.clipboard, 'readText');
+
+      expect(() => {
+        navigator.clipboard.readText().then();
+      }).not.toThrowError();
+    });
+  });
+
   describe('.match()', () => {
     it('finds matching method calls', () => {
-      const asyncStub = new AsyncMethodController(
+      const controller = new AsyncMethodController(
         navigator.clipboard,
         'writeText',
       );
@@ -11,7 +22,7 @@ describe('AsyncMethodController', () => {
       navigator.clipboard.writeText('value 2');
       navigator.clipboard.writeText('value 3');
 
-      const matches = asyncStub.match((call) => call.args[0] !== 'value 2');
+      const matches = controller.match((call) => call.args[0] !== 'value 2');
 
       expect(matches.map((match) => match.callInfo.args[0])).toEqual(
         jasmine.arrayWithExactContents(['value 1', 'value 3']),
@@ -19,36 +30,36 @@ describe('AsyncMethodController', () => {
     });
 
     it('does not remove the matching calls from future matching', () => {
-      const asyncStub = new AsyncMethodController(
+      const controller = new AsyncMethodController(
         navigator.clipboard,
         'readText',
       );
       navigator.clipboard.readText();
       navigator.clipboard.readText();
 
-      asyncStub.match(() => true);
-      const matchesOnSecondTry = asyncStub.match(() => true);
+      controller.match(() => true);
+      const matchesOnSecondTry = controller.match(() => true);
 
       expect(matchesOnSecondTry.length).toEqual(2);
     });
 
     it('returns an empty array when there have been no calls', () => {
-      const asyncStub = new AsyncMethodController(
+      const controller = new AsyncMethodController(
         navigator.clipboard,
         'readText',
       );
-      const matches = asyncStub.match(() => false);
+      const matches = controller.match(() => false);
       expect(matches).toEqual([]);
     });
 
     it('can gracefully handle when no calls match', () => {
-      const asyncStub = new AsyncMethodController(
+      const controller = new AsyncMethodController(
         navigator.clipboard,
         'readText',
       );
       navigator.clipboard.readText();
 
-      const matches = asyncStub.match(() => false);
+      const matches = controller.match(() => false);
 
       expect(matches).toEqual([]);
     });

--- a/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
@@ -254,7 +254,35 @@ describe('AsyncMethodController', () => {
     });
   });
 
-  describe('.buildErrorMessage()', () => {
+  describe('.#ensureCallInfoIsSet()', () => {
+    it('correctly initializes TestCall objects even after others have been matched', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'writeText',
+      );
+
+      // make call1, causing:
+      // testCalls: [call1]
+      // spy.calls: [call1]
+      navigator.clipboard.writeText('call1');
+
+      // match call1, causing:
+      // testCalls: []
+      // spy.calls: [call1]
+      controller.expectOne(() => true);
+
+      // make call2, causing:
+      // testCalls: [call2]
+      // spy.calls: [call1, call2]
+      navigator.clipboard.writeText('call2');
+
+      // try matching call2
+      const testCall = controller.expectOne(() => true);
+      expect(testCall.callInfo.args[0]).toBe('call2');
+    });
+  });
+
+  describe('.#buildErrorMessage()', () => {
     it('includes the given description when throwing an error', () => {
       const controller = new AsyncMethodController(
         navigator.clipboard,

--- a/projects/ng-dev/src/lib/spies/async-method-controller.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.ts
@@ -1,4 +1,5 @@
 import { Deferred } from '@s-libs/js-core';
+import { pull } from '@s-libs/micro-dash';
 import { nth } from '../../to-replace/micro-dash/nth';
 import { TestCall } from './test-call';
 
@@ -21,8 +22,27 @@ export class AsyncMethodController<
     }) as any); // TODO: make this typing better (instead of using any)
   }
 
-  // TODO: match the type of the method for CallInfo
+  expectOne(
+    // TODO: make this typing better (instead of using any)
+    match: (callInfo: jasmine.CallInfo<(...args: any[]) => any>) => boolean,
+    description?: string,
+  ): TestCall {
+    const matches = this.match(match);
+    if (matches.length !== 1) {
+      description ??= 'Match by function: ' + match.name;
+      const numMatches = matches.length || 'none';
+      throw new Error(
+        `Expected one matching request for criterion "${description}", found ${numMatches}`,
+      );
+    }
+
+    const testCall = matches[0];
+    pull(this.#testCalls, testCall);
+    return testCall;
+  }
+
   match(
+    // TODO: make this typing better (instead of using any)
     match: (callInfo: jasmine.CallInfo<(...args: any[]) => any>) => boolean,
   ): TestCall[] {
     this.ensureCallInfoIsSet();

--- a/projects/ng-dev/src/lib/spies/async-method-controller.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.ts
@@ -1,5 +1,6 @@
 import { Deferred } from '@s-libs/js-core';
 import { isEqual, nth, pull } from '@s-libs/micro-dash';
+import { AngularContext } from '../test-context';
 import { TestCall } from './test-call';
 
 type AsyncFunc = (...args: any[]) => Promise<any>;
@@ -16,11 +17,18 @@ export class AsyncMethodController<
   #spy: jasmine.Spy<O[N]>;
   #testCalls: TestCall[] = [];
 
-  constructor(obj: O, methodName: N) {
+  /**
+   * @param context TODO: suggest users pass this in if the function they are stubbing can be found in https://github.com/angular/angular/blob/master/packages/zone.js/STANDARD-APIS.md
+   */
+  constructor(
+    obj: O,
+    methodName: N,
+    { context = undefined as AngularContext | undefined } = {},
+  ) {
     this.#spy = spyOn(obj, methodName as any) as any;
     this.#spy.and.callFake((() => {
       const deferred = new Deferred();
-      this.#testCalls.push(new TestCall(deferred));
+      this.#testCalls.push(new TestCall(deferred, context));
       return deferred.promise;
     }) as any); // TODO: make this typing better (instead of using any)
   }

--- a/projects/ng-dev/src/lib/spies/async-method-controller.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.ts
@@ -54,10 +54,7 @@ export class AsyncMethodController<
         }),
       );
     }
-
-    const testCall = matches[0];
-    pull(this.#testCalls, testCall);
-    return testCall;
+    return matches[0];
   }
 
   expectNone(
@@ -83,7 +80,7 @@ export class AsyncMethodController<
     const filterFn = Array.isArray(match)
       ? this.makeArgumentMatcher(match)
       : match;
-    return this.#testCalls.filter((testCall) => filterFn(testCall.callInfo));
+    return remove(this.#testCalls, (testCall) => filterFn(testCall.callInfo));
   }
 
   verify(): void {

--- a/projects/ng-dev/src/lib/spies/async-method-controller.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.ts
@@ -143,7 +143,6 @@ export class AsyncMethodController<
     }
   }
 
-  // TODO: when we have expectOne(), test that this works with mismatched arrays
   private ensureCallInfoIsSet(): void {
     for (let i = 1; i <= this.#testCalls.length; ++i) {
       const testCall = nth(this.#testCalls, -i);
@@ -194,7 +193,6 @@ export class AsyncMethodController<
   }
 }
 
-// TODO: when we have expectOne(), test that this works with mismatched arrays
 /** @hidden */
 function stringifyArgs(args: any[]): string {
   return JSON.stringify(args);

--- a/projects/ng-dev/src/lib/spies/async-method-controller.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.ts
@@ -1,6 +1,5 @@
 import { Deferred } from '@s-libs/js-core';
-import { isEqual, pull } from '@s-libs/micro-dash';
-import { nth } from '../../to-replace/micro-dash/nth';
+import { isEqual, nth, pull } from '@s-libs/micro-dash';
 import { TestCall } from './test-call';
 
 type AsyncFunc = (...args: any[]) => Promise<any>;

--- a/projects/ng-dev/src/lib/spies/async-method-controller.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.ts
@@ -1,0 +1,25 @@
+import { TestCall } from './test-call';
+
+type AsyncFunc = (...args: any[]) => Promise<any>;
+
+// TODO: put some effort into the DX to infer T
+export class AsyncMethodController<
+  N extends PropertyKey,
+  O extends { [k in N]: AsyncFunc }
+> {
+  #spy: jasmine.Spy<O[N]>;
+
+  constructor(obj: O, methodName: N) {
+    this.#spy = spyOn(obj, methodName as any) as any;
+  }
+
+  // TODO: match the type of the method for CallInfo
+  match(
+    match: (call: jasmine.CallInfo<(...args: any[]) => any>) => boolean,
+  ): TestCall[] {
+    return this.#spy.calls
+      .all()
+      .filter(match)
+      .map((call) => new TestCall(call));
+  }
+}

--- a/projects/ng-dev/src/lib/spies/index.ts
+++ b/projects/ng-dev/src/lib/spies/index.ts
@@ -1,3 +1,5 @@
+export { AsyncMethodController } from './async-method-controller';
 export { createSpyObject } from './create-spy-object';
 export { expectCallsAndReset } from './expect-calls-and-reset';
 export { expectSingleCallAndReset } from './expect-single-call-and-reset';
+export { TestCall } from './test-call';

--- a/projects/ng-dev/src/lib/spies/test-call.spec.ts
+++ b/projects/ng-dev/src/lib/spies/test-call.spec.ts
@@ -52,7 +52,7 @@ describe('TestCall', () => {
       const controller = new AsyncMethodController(
         navigator.clipboard,
         'readText',
-        { context: ctx },
+        { ctx },
       );
 
       ctx.run(() => {
@@ -87,7 +87,7 @@ describe('TestCall', () => {
       const controller = new AsyncMethodController(
         navigator.clipboard,
         'readText',
-        { context: ctx },
+        { ctx },
       );
 
       ctx.run(() => {

--- a/projects/ng-dev/src/lib/spies/test-call.spec.ts
+++ b/projects/ng-dev/src/lib/spies/test-call.spec.ts
@@ -3,6 +3,22 @@ import { AsyncMethodController } from './async-method-controller';
 import { expectSingleCallAndReset } from './expect-single-call-and-reset';
 
 describe('TestCall', () => {
+  describe('.callInfo', () => {
+    it('is populated with a jasmine.CallInfo object', () => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'readText',
+      );
+      navigator.clipboard.readText();
+
+      const callInfo = controller.expectOne([]).callInfo;
+
+      // We'd love to test that this is just an "instanceof jasmine.CallInfo", but that's not really a thing. So we'll approximate it by ensuring a couple properties exist.
+      expect(callInfo.returnValue).toBeInstanceOf(Promise);
+      expect(callInfo.object).toBe(navigator.clipboard);
+    });
+  });
+
   describe('.flush()', () => {
     it('causes the call to be fulfilled with the given value', fakeAsync(() => {
       const controller = new AsyncMethodController(

--- a/projects/ng-dev/src/lib/spies/test-call.spec.ts
+++ b/projects/ng-dev/src/lib/spies/test-call.spec.ts
@@ -4,7 +4,7 @@ import { expectSingleCallAndReset } from './expect-single-call-and-reset';
 
 describe('TestCall', () => {
   describe('.flush()', () => {
-    it('causes the call to resolve with the given value', fakeAsync(() => {
+    it('causes the call to be fulfilled with the given value', fakeAsync(() => {
       const controller = new AsyncMethodController(
         navigator.clipboard,
         'readText',
@@ -17,6 +17,23 @@ describe('TestCall', () => {
       flushMicrotasks();
 
       expectSingleCallAndReset(spy, 'the clipboard text');
+    }));
+  });
+
+  describe('.error()', () => {
+    it('causes the call to be rejected with the given reason', fakeAsync(() => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'readText',
+      );
+      const spy = jasmine.createSpy();
+      navigator.clipboard.readText().catch(spy);
+      const testCall = controller.match(() => true)[0];
+
+      testCall.error('some problem');
+      flushMicrotasks();
+
+      expectSingleCallAndReset(spy, 'some problem');
     }));
   });
 });

--- a/projects/ng-dev/src/lib/spies/test-call.spec.ts
+++ b/projects/ng-dev/src/lib/spies/test-call.spec.ts
@@ -1,5 +1,22 @@
+import { fakeAsync, flushMicrotasks } from '@angular/core/testing';
+import { AsyncMethodController } from './async-method-controller';
+import { expectSingleCallAndReset } from './expect-single-call-and-reset';
+
 describe('TestCall', () => {
-  it('', () => {
-    fail('write this test');
+  describe('.flush()', () => {
+    it('causes the call to resolve with the given value', fakeAsync(() => {
+      const controller = new AsyncMethodController(
+        navigator.clipboard,
+        'readText',
+      );
+      const spy = jasmine.createSpy();
+      navigator.clipboard.readText().then(spy);
+      const testCall = controller.match(() => true)[0];
+
+      testCall.flush('the clipboard text');
+      flushMicrotasks();
+
+      expectSingleCallAndReset(spy, 'the clipboard text');
+    }));
   });
 });

--- a/projects/ng-dev/src/lib/spies/test-call.spec.ts
+++ b/projects/ng-dev/src/lib/spies/test-call.spec.ts
@@ -1,0 +1,5 @@
+describe('TestCall', () => {
+  it('', () => {
+    fail('write this test');
+  });
+});

--- a/projects/ng-dev/src/lib/spies/test-call.ts
+++ b/projects/ng-dev/src/lib/spies/test-call.ts
@@ -1,18 +1,25 @@
 import { Deferred } from '@s-libs/js-core';
+import { AngularContext } from '../test-context';
 
 export class TestCall {
   // TODO: make this typing better (instead of using any)
   callInfo!: jasmine.CallInfo<any>;
 
   // TODO: make this typing better (instead of using any)
-  constructor(private deferred: Deferred<any>) {}
+  constructor(
+    private deferred: Deferred<any>,
+    private context?: AngularContext,
+  ) {}
 
   // TODO: make this typing better (instead of using any)
   flush(value: any): void {
     this.deferred.resolve(value);
+    this.context?.tick();
   }
 
+  // TODO: make this typing better (instead of using any)
   error(reason: any): void {
     this.deferred.reject(reason);
+    this.context?.tick();
   }
 }

--- a/projects/ng-dev/src/lib/spies/test-call.ts
+++ b/projects/ng-dev/src/lib/spies/test-call.ts
@@ -1,6 +1,7 @@
 import { Deferred } from '@s-libs/js-core';
 
 export class TestCall {
+  // TODO: make this typing better (instead of using any)
   callInfo!: jasmine.CallInfo<any>;
 
   // TODO: make this typing better (instead of using any)
@@ -9,5 +10,9 @@ export class TestCall {
   // TODO: make this typing better (instead of using any)
   flush(value: any): void {
     this.deferred.resolve(value);
+  }
+
+  error(reason: any): void {
+    this.deferred.reject(reason);
   }
 }

--- a/projects/ng-dev/src/lib/spies/test-call.ts
+++ b/projects/ng-dev/src/lib/spies/test-call.ts
@@ -1,23 +1,20 @@
 import { Deferred } from '@s-libs/js-core';
+import { PromiseType } from 'utility-types';
 import { AngularContext } from '../test-context';
 
-export class TestCall {
-  // TODO: make this typing better (instead of using any)
-  callInfo!: jasmine.CallInfo<any>;
+export class TestCall<F extends jasmine.Func> {
+  callInfo!: jasmine.CallInfo<F>;
 
-  // TODO: make this typing better (instead of using any)
   constructor(
-    private deferred: Deferred<any>,
+    private deferred: Deferred<PromiseType<ReturnType<F>>>,
     private context?: AngularContext,
   ) {}
 
-  // TODO: make this typing better (instead of using any)
-  flush(value: any): void {
+  flush(value: PromiseType<ReturnType<F>>): void {
     this.deferred.resolve(value);
     this.context?.tick();
   }
 
-  // TODO: make this typing better (instead of using any)
   error(reason: any): void {
     this.deferred.reject(reason);
     this.context?.tick();

--- a/projects/ng-dev/src/lib/spies/test-call.ts
+++ b/projects/ng-dev/src/lib/spies/test-call.ts
@@ -1,4 +1,13 @@
+import { Deferred } from '@s-libs/js-core';
+
 export class TestCall {
+  callInfo!: jasmine.CallInfo<any>;
+
   // TODO: make this typing better (instead of using any)
-  constructor(public callInfo: jasmine.CallInfo<any>) {}
+  constructor(private deferred: Deferred<any>) {}
+
+  // TODO: make this typing better (instead of using any)
+  flush(value: any): void {
+    this.deferred.resolve(value);
+  }
 }

--- a/projects/ng-dev/src/lib/spies/test-call.ts
+++ b/projects/ng-dev/src/lib/spies/test-call.ts
@@ -1,0 +1,4 @@
+export class TestCall {
+  // TODO: make this typing better (instead of using any)
+  constructor(public callInfo: jasmine.CallInfo<any>) {}
+}

--- a/projects/ng-dev/src/lib/spies/test-call.ts
+++ b/projects/ng-dev/src/lib/spies/test-call.ts
@@ -2,21 +2,31 @@ import { Deferred } from '@s-libs/js-core';
 import { PromiseType } from 'utility-types';
 import { AngularContext } from '../test-context';
 
+/**
+ * A mock method call that was made and is ready to be answered. This interface allows access to the underlying <code>jasmine.CallInfo</code>, and allows resolving or rejecting the asynchronous call's result.
+ */
 export class TestCall<F extends jasmine.Func> {
+  /** The underlying jasmine call object */
   callInfo!: jasmine.CallInfo<F>;
 
   constructor(
     private deferred: Deferred<PromiseType<ReturnType<F>>>,
-    private context?: AngularContext,
+    private ctx?: AngularContext,
   ) {}
 
+  /**
+   * Resolve the call with the given value.
+   */
   flush(value: PromiseType<ReturnType<F>>): void {
     this.deferred.resolve(value);
-    this.context?.tick();
+    this.ctx?.tick();
   }
 
+  /**
+   * Reject the call with the given reason.
+   */
   error(reason: any): void {
     this.deferred.reject(reason);
-    this.context?.tick();
+    this.ctx?.tick();
   }
 }

--- a/projects/ng-dev/src/to-replace/micro-dash/nth.ts
+++ b/projects/ng-dev/src/to-replace/micro-dash/nth.ts
@@ -1,0 +1,6 @@
+export function nth<T>(array: ReadonlyArray<T>, index: number): T {
+  if (index < 0) {
+    index = array.length + index;
+  }
+  return array[index];
+}

--- a/projects/ng-dev/src/to-replace/micro-dash/nth.ts
+++ b/projects/ng-dev/src/to-replace/micro-dash/nth.ts
@@ -1,6 +1,0 @@
-export function nth<T>(array: ReadonlyArray<T>, index: number): T {
-  if (index < 0) {
-    index = array.length + index;
-  }
-  return array[index];
-}

--- a/projects/ng-dev/src/typing-tests/async-method-controller.dts-spec.ts
+++ b/projects/ng-dev/src/typing-tests/async-method-controller.dts-spec.ts
@@ -1,0 +1,33 @@
+import { AsyncMethodController } from '../lib/spies';
+
+export type Evaluate<T> = T extends infer I ? { [K in keyof I]: T[K] } : never;
+
+const writeController = new AsyncMethodController(
+  navigator.clipboard,
+  'writeText',
+);
+const readController = new AsyncMethodController(
+  navigator.clipboard,
+  'readText',
+);
+
+// $ExpectType [data: string] | {}
+type writeExpectOneMatchType = Evaluate<
+  Parameters<typeof writeController.expectOne>[0]
+>;
+writeController.expectOne(
+  (
+    // $ExpectType CallInfo<(data: string) => Promise<void>>
+    callInfo,
+  ) => true,
+);
+// $ExpectType [] | {}
+type readExpectOneMatchType = Evaluate<
+  Parameters<typeof readController.expectOne>[0]
+>;
+readController.expectOne(
+  (
+    // $ExpectType CallInfo<() => Promise<string>>
+    callInfo,
+  ) => true,
+);

--- a/projects/ng-dev/src/typing-tests/test-call.dts-spec.ts
+++ b/projects/ng-dev/src/typing-tests/test-call.dts-spec.ts
@@ -1,0 +1,23 @@
+import { AsyncMethodController } from '../lib/spies';
+
+const writeController = new AsyncMethodController(
+  navigator.clipboard,
+  'writeText',
+);
+const readController = new AsyncMethodController(
+  navigator.clipboard,
+  'readText',
+);
+
+const writeTestCall = writeController.expectOne(['something I copied']);
+const readTestCall = readController.expectOne([]);
+
+// $ExpectType [data: string]
+const writeArgs = writeTestCall.callInfo.args;
+// $ExpectType []
+const readArgs = readTestCall.callInfo.args;
+
+// $ExpectType (value: void) => void
+const writeFlush = writeTestCall.flush;
+// $ExpectType (value: string) => void
+const readFlush = readTestCall.flush;


### PR DESCRIPTION
Add `AsyncMethodController` to mock any asynchronous method and interact with it the same way as Angular's test framework for network requests.