### PR TITLE
Allow await in tests, use it for harnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [11.2.0-next.1](https://github.com/simontonsoftware/s-libs/compare/v11.2.0-next.0...v11.2.0-next.1) (2021-01-01)
+
+### Features
+
+- **ng-core:** `DirectiveSuperclass.getInput$()` wait until the input is set before emitting. Before, if called e.g. from the directive's constructor, it would emit `undefined` immediately, then emit again during `ngOnChanges`. **Caveat:** all emissions are now delayed on the microtask queue. ([3b13611](https://github.com/simontonsoftware/s-libs/commit/3b13611044b28c9a00d07b0e73210831659f7f6d)), closes [#14](https://github.com/simontonsoftware/s-libs/issues/14)
+- **ng-dev:** add `ComponentContextNext`. This will replace `ComponentContext` in a future major version release. See migration notes in the class-level docs for `ComponentContext`. Closes [#15](https://github.com/simontonsoftware/s-libs/issues/15). ([90bc99f](https://github.com/simontonsoftware/s-libs/commit/90bc99f72995bd757e02eda7ec2bf3e51751c7d4))
+
 ## [11.2.0-next.0](https://github.com/simontonsoftware/s-libs/compare/v11.1.0...v11.2.0-next.0) (2020-12-19)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s-libs",
-  "version": "11.2.0-next.0",
+  "version": "11.2.0-next.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/app-state/package.json
+++ b/projects/app-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-libs/app-state",
-  "version": "11.2.0-next.0",
+  "version": "11.2.0-next.1",
   "author": "Simonton Software",
   "license": "MIT",
   "homepage": "https://github.com/simontonsoftware/s-libs/tree/master/projects/app-state",
@@ -10,9 +10,9 @@
     "directory": "projects/app-state"
   },
   "peerDependencies": {
-    "@s-libs/js-core": "^11.2.0-next.0",
-    "@s-libs/micro-dash": "^11.2.0-next.0",
-    "@s-libs/rxjs-core": "^11.2.0-next.0"
+    "@s-libs/js-core": "^11.2.0-next.1",
+    "@s-libs/micro-dash": "^11.2.0-next.1",
+    "@s-libs/rxjs-core": "^11.2.0-next.1"
   },
   "dependencies": { "tslib": "^2.0.0" }
 }

--- a/projects/integration/src/app/api-tests/ng-core.spec.ts
+++ b/projects/integration/src/app/api-tests/ng-core.spec.ts
@@ -291,7 +291,8 @@ describe('ng-core', () => {
         flushMicrotasks();
       }
 
-      ctx.run({ inputs: { string: 'initial value' } }, () => {
+      ctx.assignInputs({ string: 'initial value' });
+      ctx.run(() => {
         expect(stringInput().value).toBe('initial value');
 
         setValue(stringInput(), 'edited value');
@@ -405,7 +406,8 @@ describe('ng-core', () => {
         flushMicrotasks();
       }
 
-      ctx.run({ inputs: { shouldDisable: true } }, () => {
+      ctx.assignInputs({ shouldDisable: true });
+      ctx.run(() => {
         expect(incrementButton().disabled).toBe(true);
 
         click(toggleDisabledButton());

--- a/projects/integration/src/app/api-tests/ng-dev.spec.ts
+++ b/projects/integration/src/app/api-tests/ng-dev.spec.ts
@@ -1,5 +1,6 @@
 import {
   AngularContext,
+  AngularContextNext,
   AsyncMethodController,
   ComponentContext,
   ComponentContextNext,
@@ -16,6 +17,10 @@ import {
 describe('ng-dev', () => {
   it('has AngularContext', () => {
     expect(AngularContext).toBeDefined();
+  });
+
+  it('has AngularContextNext', () => {
+    expect(AngularContextNext).toBeDefined();
   });
 
   it('has AsyncMethodController', () => {

--- a/projects/js-core/package.json
+++ b/projects/js-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-libs/js-core",
-  "version": "11.2.0-next.0",
+  "version": "11.2.0-next.1",
   "author": "Simonton Software",
   "license": "MIT",
   "homepage": "https://github.com/simontonsoftware/s-libs/tree/master/projects/js-core",
@@ -9,6 +9,6 @@
     "url": "https://github.com/simontonsoftware/s-libs.git",
     "directory": "projects/js-core"
   },
-  "peerDependencies": { "@s-libs/micro-dash": "^11.2.0-next.0" },
+  "peerDependencies": { "@s-libs/micro-dash": "^11.2.0-next.1" },
   "dependencies": { "tslib": "^2.0.0" }
 }

--- a/projects/micro-dash/package.json
+++ b/projects/micro-dash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-libs/micro-dash",
-  "version": "11.2.0-next.0",
+  "version": "11.2.0-next.1",
   "description": "Lightweight implementations of simplified lodash functions",
   "author": "Simonton Software",
   "license": "MIT",

--- a/projects/ng-app-state/package.json
+++ b/projects/ng-app-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-libs/ng-app-state",
-  "version": "11.2.0-next.0",
+  "version": "11.2.0-next.1",
   "author": "Simonton Software",
   "license": "MIT",
   "homepage": "https://github.com/simontonsoftware/s-libs/tree/master/projects/ng-app-state",
@@ -12,10 +12,10 @@
   "peerDependencies": {
     "@angular/common": "^11.0.0",
     "@angular/core": "^11.0.0",
-    "@s-libs/js-core": "^11.2.0-next.0",
-    "@s-libs/micro-dash": "^11.2.0-next.0",
-    "@s-libs/ng-core": "^11.2.0-next.0",
-    "@s-libs/rxjs-core": "^11.2.0-next.0"
+    "@s-libs/js-core": "^11.2.0-next.1",
+    "@s-libs/micro-dash": "^11.2.0-next.1",
+    "@s-libs/ng-core": "^11.2.0-next.1",
+    "@s-libs/rxjs-core": "^11.2.0-next.1"
   },
   "dependencies": { "tslib": "^2.0.0" }
 }

--- a/projects/ng-core/package.json
+++ b/projects/ng-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-libs/ng-core",
-  "version": "11.2.0-next.0",
+  "version": "11.2.0-next.1",
   "author": "Simonton Software",
   "license": "MIT",
   "homepage": "https://github.com/simontonsoftware/s-libs/tree/master/projects/ng-core",
@@ -12,9 +12,9 @@
   "peerDependencies": {
     "@angular/common": "^11.0.0",
     "@angular/core": "^11.0.0",
-    "@s-libs/js-core": "^11.2.0-next.0",
-    "@s-libs/micro-dash": "^11.2.0-next.0",
-    "@s-libs/rxjs-core": "^11.2.0-next.0"
+    "@s-libs/js-core": "^11.2.0-next.1",
+    "@s-libs/micro-dash": "^11.2.0-next.1",
+    "@s-libs/rxjs-core": "^11.2.0-next.1"
   },
   "dependencies": { "tslib": "^2.0.0" }
 }

--- a/projects/ng-core/src/lib/directive-superclass.spec.ts
+++ b/projects/ng-core/src/lib/directive-superclass.spec.ts
@@ -188,7 +188,8 @@ describe('DirectiveSuperclass', () => {
       }
 
       const ctx2 = new ComponentContextNext(TestDirective);
-      ctx2.run({ inputs: { specified: 'a value' } }, () => {
+      ctx2.assignInputs({ specified: 'a value' });
+      ctx2.run(() => {
         const testDirective = ctx2.getComponentInstance();
         expect(testDirective.emittedValue).toBe(undefined);
       });

--- a/projects/ng-core/src/lib/form-control-superclass.spec.ts
+++ b/projects/ng-core/src/lib/form-control-superclass.spec.ts
@@ -79,7 +79,8 @@ describe('FormControlSuperclass', () => {
   ///////
 
   it('provides help for 2-way binding', () => {
-    ctx.run({ inputs: { value: 15 } }, () => {
+    ctx.assignInputs({ value: 15 });
+    ctx.run(() => {
       expect(ctx.getComponentInstance().value).toBe(15);
       expect(ctx.fixture.nativeElement.innerText).toContain('15');
 
@@ -98,7 +99,8 @@ describe('FormControlSuperclass', () => {
   });
 
   it('provides help for `[disabled]`', () => {
-    ctx.run({ inputs: { shouldDisable: true } }, () => {
+    ctx.assignInputs({ shouldDisable: true });
+    ctx.run(() => {
       expect(incrementButton().disabled).toBe(true);
 
       click(toggleDisabledButton());

--- a/projects/ng-dev/package.json
+++ b/projects/ng-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-libs/ng-dev",
-  "version": "11.2.0-next.0",
+  "version": "11.2.0-next.1",
   "author": "Simonton Software",
   "license": "MIT",
   "homepage": "https://github.com/simontonsoftware/s-libs/tree/master/projects/ng-dev",
@@ -13,10 +13,10 @@
     "@angular/cdk": "^11.0.0",
     "@angular/common": "^11.0.0",
     "@angular/core": "^11.0.0",
-    "@s-libs/js-core": "^11.2.0-next.0",
-    "@s-libs/micro-dash": "^11.2.0-next.0",
-    "@s-libs/ng-core": "^11.2.0-next.0",
-    "@s-libs/rxjs-core": "^11.2.0-next.0",
+    "@s-libs/js-core": "^11.2.0-next.1",
+    "@s-libs/micro-dash": "^11.2.0-next.1",
+    "@s-libs/ng-core": "^11.2.0-next.1",
+    "@s-libs/rxjs-core": "^11.2.0-next.1",
     "jasmine-core": "^3.6.0"
   },
   "dependencies": {

--- a/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.spec.ts
@@ -1,4 +1,4 @@
-import { AngularContext } from '../test-context';
+import { AngularContextNext } from '../test-context/angular-context/angular-context-next';
 import { AsyncMethodController } from './async-method-controller';
 
 describe('AsyncMethodController', () => {
@@ -343,7 +343,7 @@ describe('AsyncMethodController', () => {
   describe('examples from the docs', () => {
     it('can paste', () => {
       const clipboard = navigator.clipboard;
-      const ctx = new AngularContext();
+      const ctx = new AngularContextNext();
 
       // mock the browser API for pasting
       const controller = new AsyncMethodController(clipboard, 'readText', {

--- a/projects/ng-dev/src/lib/spies/async-method-controller.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.ts
@@ -24,11 +24,11 @@ type AsyncMethodKeys<T> = {
  * ```ts
  *  it('can paste', () => {
  *   const clipboard = navigator.clipboard;
- *   const ctx = new AngularContext();
+ *   const ctx = new AngularContextNext();
  *
  *   // mock the browser API for pasting
  *   const controller = new AsyncMethodController(clipboard, 'readText', {
- *     context: ctx,
+ *     ctx,
  *   });
  *   ctx.run(() => {
  *     // BEGIN production code that copies to the clipboard
@@ -63,7 +63,7 @@ export class AsyncMethodController<
     methodName: FunctionName,
     { ctx = undefined as { tick(): void } | undefined } = {},
   ) {
-    // Note: it wasn't immediately clear how avoid `any` in this constructor, and this will be invisible to users. So I gave up. (For now.)
+    // Note: it wasn't immediately clear how avoid `any` in this constructor, and this will be invisible to users. So I gave up. (For now?)
     this.#spy = spyOn(obj, methodName as any) as any;
     this.#spy.and.callFake((() => {
       const deferred = new Deferred<any>();

--- a/projects/ng-dev/src/lib/spies/async-method-controller.ts
+++ b/projects/ng-dev/src/lib/spies/async-method-controller.ts
@@ -1,6 +1,5 @@
 import { Deferred } from '@s-libs/js-core';
 import { isEqual, nth, remove } from '@s-libs/micro-dash';
-import { AngularContext } from '../test-context';
 import { TestCall } from './test-call';
 
 /** @hidden */
@@ -62,7 +61,7 @@ export class AsyncMethodController<
   constructor(
     obj: WrappingObject,
     methodName: FunctionName,
-    { ctx = undefined as AngularContext | undefined } = {},
+    { ctx = undefined as { tick(): void } | undefined } = {},
   ) {
     // Note: it wasn't immediately clear how avoid `any` in this constructor, and this will be invisible to users. So I gave up. (For now.)
     this.#spy = spyOn(obj, methodName as any) as any;

--- a/projects/ng-dev/src/lib/spies/test-call.ts
+++ b/projects/ng-dev/src/lib/spies/test-call.ts
@@ -1,6 +1,5 @@
 import { Deferred } from '@s-libs/js-core';
 import { PromiseType } from 'utility-types';
-import { AngularContext } from '../test-context';
 
 /**
  * A mock method call that was made and is ready to be answered. This interface allows access to the underlying <code>jasmine.CallInfo</code>, and allows resolving or rejecting the asynchronous call's result.
@@ -11,7 +10,7 @@ export class TestCall<F extends jasmine.Func> {
 
   constructor(
     private deferred: Deferred<PromiseType<ReturnType<F>>>,
-    private ctx?: AngularContext,
+    private ctx?: { tick(): void },
   ) {}
 
   /**

--- a/projects/ng-dev/src/lib/test-context/angular-context/angular-context-next.ts
+++ b/projects/ng-dev/src/lib/test-context/angular-context/angular-context-next.ts
@@ -1,0 +1,219 @@
+import { ComponentHarness, HarnessQuery } from '@angular/cdk/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import {
+  AbstractType,
+  ApplicationRef,
+  InjectionToken,
+  Type,
+} from '@angular/core';
+import {
+  discardPeriodicTasks,
+  fakeAsync,
+  flushMicrotasks,
+  TestBed,
+  TestModuleMetadata,
+  tick,
+} from '@angular/core/testing';
+import { convertTime } from '@s-libs/js-core';
+import { clone, forOwn } from '@s-libs/micro-dash';
+import { Synchronized } from '../synchronize';
+import { FakeAsyncHarnessEnvironment } from './fake-async-harness-environment';
+
+/** @hidden */
+export function extendMetadata(
+  metadata: TestModuleMetadata,
+  toAdd: TestModuleMetadata,
+): TestModuleMetadata {
+  const result: any = clone(metadata);
+  forOwn(toAdd, (val, key) => {
+    result[key] = Array.isArray(result[key]) ? result[key].concat(val) : val;
+  });
+  return result;
+}
+
+/**
+ * Provides the foundation for an opinionated testing pattern.
+ * - All test are run in the `fakeAsync` zone. This gives you full control over
+ *   the timing of everything by default.
+ * - Variables that are initialized for each test exist in a context that is
+ *   thrown away, so they cannot leak between tests.
+ * - Clearly separates initialization code from the test itself.
+ * - Gives control over the simulated date & time with a single line of code.
+ * - Automatically includes {@link HttpClientTestingModule} to stub network requests without additional setup.
+ * - Always verifies no unexpected http requests were made during a test.
+ * - Always discards periodic tasks at the end of each test to automatically
+ *   avoid an error from the `fakeAsync` zone.
+ *
+ * This example tests a simple service that uses HttpClient, and is tested by
+ * using `AngularContext` directly. More often `AngularContext` will be used a
+ * super class. See {@link ComponentContextNext} for more common use cases.
+ * ```ts
+ *  // This is the class we will test.
+ *  @Injectable({ providedIn: 'root' })
+ *  class MemoriesService {
+ *   constructor(private httpClient: HttpClient) {}
+ *
+ *   getLastYearToday(): Observable<any> {
+ *     const datetime = new Date();
+ *     datetime.setFullYear(datetime.getFullYear() - 1);
+ *     const date = datetime.toISOString().split('T')[0];
+ *     return this.httpClient.get(`http://example.com/post-from/${date}`);
+ *   }
+ * }
+ *
+ *  describe('MemoriesService', () => {
+ *
+ *   // Tests should have exactly 1 variable outside an "it": `ctx`.
+ *   let ctx: AngularContext;
+ *   beforeEach(() => {
+ *     ctx = new AngularContext();
+ *   });
+ *
+ *   it('requests a post from 1 year ago', () => {
+ *
+ *     // Before calling `run`, set up any context variables this test needs.
+ *     ctx.startTime = new Date('2004-02-16T10:15:00.000Z');
+ *
+ *     // Pass the test itself as a callback to `run()`.
+ *     ctx.run(() => {
+ *       const httpBackend = ctx.inject(HttpTestingController);
+ *       const myService = ctx.inject(MemoriesService);
+ *
+ *       myService.getLastYearToday().subscribe();
+ *
+ *       httpBackend.expectOne('http://example.com/post-from/2003-02-16');
+ *     });
+ *   });
+ * });
+ * ```
+ */
+export class AngularContextNext {
+  /**
+   * Set this before calling `run()` to mock the time at which the test starts.
+   */
+  startTime = new Date();
+
+  private loader = FakeAsyncHarnessEnvironment.documentRootLoader(this);
+
+  /**
+   * @param moduleMetadata passed along to [TestBed.configureTestingModule()]{@linkcode https://angular.io/api/core/testing/TestBed#configureTestingModule}. Automatically includes {@link HttpClientTestingModule} for you.
+   */
+  constructor(moduleMetadata: TestModuleMetadata = {}) {
+    TestBed.configureTestingModule(
+      extendMetadata(moduleMetadata, { imports: [HttpClientTestingModule] }),
+    );
+  }
+
+  /**
+   * Runs `test` in a `fakeAsync` zone. Also runs the following in this order, all within the same zone:
+   * 1. `init(options)`
+   * 2. `test()`
+   * 3. `verifyPostTestConditions()`
+   * 4. `cleanUp()`
+   *
+   * @param options Passed along to `init()`. Unused by `AngularContext`, but may be used by subclasses.
+   */
+  run(test: () => void): void {
+    this.runWithMockedTime(() => {
+      this.init();
+      try {
+        test();
+        this.verifyPostTestConditions();
+      } finally {
+        this.cleanUp();
+      }
+    });
+  }
+
+  /**
+   * Gets a service or other injectable from the root injector. This implementation is a simple pass-through to [TestBed.inject()]{@linkcode https://angular.io/api/core/testing/TestBed#inject}, but subclasses may provide their own implementation. It is recommended to use this in your tests instead of using `TestBed` directly.
+   */
+  inject<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>): T {
+    return TestBed.inject(token);
+  }
+
+  /**
+   * Gets a component harness, wrapped for use in a fakeAsync test so that you do not need to `await` its results. Throws an error if no match can be located.
+   */
+  getHarness<T extends ComponentHarness>(
+    query: HarnessQuery<T>,
+  ): Synchronized<T> {
+    return this.loader.getHarness(query) as Synchronized<T>;
+  }
+
+  /**
+   * Gets a component harness, wrapped for use in a fakeAsync test so that you do not need to `await` its results. Returns `null` if the harness cannot be located.
+   */
+  getHarnessForOptional<T extends ComponentHarness>(
+    query: HarnessQuery<T>,
+  ): Synchronized<T> | null {
+    return this.loader.locatorForOptional(query)() as Synchronized<T> | null;
+  }
+
+  /**
+   * Gets all component harnesses that match the query, wrapped for use in a fakeAsync test so that you do not need to `await` its results.
+   */
+  getAllHarnesses<T extends ComponentHarness>(
+    query: HarnessQuery<T>,
+  ): Array<Synchronized<T>> {
+    return (this.loader.getAllHarnesses(query) as unknown) as Array<
+      Synchronized<T>
+    >;
+  }
+
+  /**
+   * Advance time and trigger change detection. It is common to call this with no arguments to trigger change detection without advancing time.
+   *
+   * @param unit The unit of time `amount` represents. Accepts anything described in `@s-libs/s-core`'s [TimeUnit]{@linkcode https://simontonsoftware.github.io/s-js-utils/typedoc/enums/timeunit.html} enum.
+   */
+  tick(amount = 0, unit = 'ms'): void {
+    // To simulate real life, trigger change detection before processing macro tasks. To further simulate real life, wait until the micro task queue is empty.
+    flushMicrotasks();
+    this.runChangeDetection();
+
+    tick(convertTime(amount, unit, 'ms'));
+    this.runChangeDetection();
+  }
+
+  /**
+   * This is a hook for subclasses to override. It is called during `run()`, before the `test()` callback. This implementation does nothing, but if you override this it is still recommended to call `super.init()` in case this implementation does something in the future.
+   */
+  protected init(): void {}
+
+  /** @hidden */
+  protected runChangeDetection(): void {
+    this.inject(ApplicationRef).tick();
+  }
+
+  /**
+   * Runs post-test verifications. This base implementation runs [HttpTestingController#verify]{@linkcode https://angular.io/api/common/http/testing/HttpTestingController#verify}. Unlike {@link #cleanUp}, it is OK for this method to throw an error to indicate a violation.
+   */
+  protected verifyPostTestConditions(): void {
+    this.inject(HttpTestingController).verify();
+  }
+
+  /**
+   * Performs any cleanup needed at the end of each test. This base implementation calls [discardPeriodicTasks]{@linkcode https://angular.io/api/core/testing/discardPeriodicTasks} to avoid an error from the `fakeAsync` zone.
+   */
+  protected cleanUp(): void {
+    discardPeriodicTasks();
+  }
+
+  private runWithMockedTime(test: VoidFunction): void {
+    // https://github.com/angular/angular/issues/31677#issuecomment-573139551
+    const now = performance.now;
+    spyOn(performance, 'now').and.callFake(() => Date.now());
+
+    jasmine.clock().install();
+    fakeAsync(() => {
+      jasmine.clock().mockDate(this.startTime);
+      test();
+    })();
+    jasmine.clock().uninstall();
+
+    performance.now = now;
+  }
+}

--- a/projects/ng-dev/src/lib/test-context/angular-context/angular-context-next.ts
+++ b/projects/ng-dev/src/lib/test-context/angular-context/angular-context-next.ts
@@ -44,9 +44,9 @@ export function extendMetadata(
  * - Always discards periodic tasks at the end of each test to automatically
  *   avoid an error from the `fakeAsync` zone.
  *
- * This example tests a simple service that uses HttpClient, and is tested by
- * using `AngularContext` directly. More often `AngularContext` will be used a
- * super class. See {@link ComponentContextNext} for more common use cases.
+ * Why does the class name end with "Next"? This replaces the old `AngularContext`, but it's a breaking change so this gives people some time to transition over. Eventually the old one will be removed and this will be renamed to `AngularContext`.
+ *
+ * This example tests a simple service that uses HttpClient, and is tested by using `AngularContextNext` directly. More often `AngularContextNext` will be used a super class. See {@link ComponentContextNext} for more common use cases.
  *
  * ```ts
  * // This is the class we will test.
@@ -102,13 +102,14 @@ export class AngularContextNext {
   }
 
   /**
-   * Runs `test` in a `fakeAsync` zone. Also runs the following in this order, all within the same zone:
-   * 1. `init(options)`
-   * 2. `test()`
-   * 3. `verifyPostTestConditions()`
-   * 4. `cleanUp()`
+   * Runs `test` in a `fakeAsync` zone. It can use async/await, but be sure anything you `await` is already due to execute (e.g. if a timeout is due in 3 seconds, call `.tick(3000)` before `await`ing its result).
    *
-   * @param options Passed along to `init()`. Unused by `AngularContext`, but may be used by subclasses.
+   * Also runs the following in this order, all within the same zone:
+   *
+   * 1. `this.init()`
+   * 2. `test()`
+   * 3. `this.verifyPostTestConditions()`
+   * 4. `this.cleanUp()`
    */
   run(test: () => void | Promise<void>): void {
     this.runWithMockedTime(() => {

--- a/projects/ng-dev/src/lib/test-context/angular-context/angular-context.ts
+++ b/projects/ng-dev/src/lib/test-context/angular-context/angular-context.ts
@@ -35,60 +35,10 @@ export function extendMetadata(
 }
 
 /**
- * Provides the foundation for an opinionated testing pattern.
- * - All test are run in the `fakeAsync` zone. This gives you full control over
- *   the timing of everything by default.
- * - Variables that are initialized for each test exist in a context that is
- *   thrown away, so they cannot leak between tests.
- * - Clearly separates initialization code from the test itself.
- * - Gives control over the simulated date & time with a single line of code.
- * - Automatically includes {@link HttpClientTestingModule} to stub network requests without additional setup.
- * - Always verifies no unexpected http requests were made during a test.
- * - Always discards periodic tasks at the end of each test to automatically
- *   avoid an error from the `fakeAsync` zone.
+ * @deprecated Use {@link AngularContextNext} instead. This old version will be removed in a future version, and `AngularContextNext` will be renamed to `AngularContext`.
  *
- * This example tests a simple service that uses HttpClient, and is tested by
- * using `AngularContext` directly. More often `AngularContext` will be used a
- * super class. See {@link ComponentContextNext} for more common use cases.
- * ```ts
- *  // This is the class we will test.
- *  @Injectable({ providedIn: 'root' })
- *  class MemoriesService {
- *   constructor(private httpClient: HttpClient) {}
- *
- *   getLastYearToday(): Observable<any> {
- *     const datetime = new Date();
- *     datetime.setFullYear(datetime.getFullYear() - 1);
- *     const date = datetime.toISOString().split('T')[0];
- *     return this.httpClient.get(`http://example.com/post-from/${date}`);
- *   }
- * }
- *
- *  describe('MemoriesService', () => {
- *
- *   // Tests should have exactly 1 variable outside an "it": `ctx`.
- *   let ctx: AngularContext;
- *   beforeEach(() => {
- *     ctx = new AngularContext();
- *   });
- *
- *   it('requests a post from 1 year ago', () => {
- *
- *     // Before calling `run`, set up any context variables this test needs.
- *     ctx.startTime = new Date('2004-02-16T10:15:00.000Z');
- *
- *     // Pass the test itself as a callback to `run()`.
- *     ctx.run(() => {
- *       const httpBackend = ctx.inject(HttpTestingController);
- *       const myService = ctx.inject(MemoriesService);
- *
- *       myService.getLastYearToday().subscribe();
- *
- *       httpBackend.expectOne('http://example.com/post-from/2003-02-16');
- *     });
- *   });
- * });
- * ```
+ * Some notes to migrate to the new version:
+ * - For any tests that were passing inputs to `.run()`, instead call `.assignInputs()` before `.run()`.
  */
 export class AngularContext<InitOptions = {}> {
   /**

--- a/projects/ng-dev/src/lib/test-context/angular-context/fake-async-harness-environment-next.spec.ts
+++ b/projects/ng-dev/src/lib/test-context/angular-context/fake-async-harness-environment-next.spec.ts
@@ -1,0 +1,52 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { Component } from '@angular/core';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatSnackBarHarness } from '@angular/material/snack-bar/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ComponentContextNext } from '../component-context';
+
+@Component({
+  template: `
+    <button mat-button (click)="clicked = true">{{ clicked }}</button>
+  `,
+})
+class TestComponent {
+  clicked = false;
+}
+
+describe('FakeAsyncHarnessEnvironmentNext', () => {
+  it('runs asynchronous events that are due automatically', () => {
+    const ctx = new ComponentContextNext(TestComponent);
+    ctx.run(async () => {
+      const button = await ctx.getHarness(MatButtonHarness);
+      await button.click();
+      expect(await button.getText()).toBe('true');
+    });
+  });
+
+  it('does not flush timeouts that are not yet due', () => {
+    class SnackBarContext extends ComponentContextNext<TestComponent> {
+      constructor() {
+        super(TestComponent, {
+          imports: [MatSnackBarModule, NoopAnimationsModule],
+        });
+      }
+
+      protected cleanUp(): void {
+        this.inject(OverlayContainer).ngOnDestroy();
+        this.tick(5000);
+        super.cleanUp();
+      }
+    }
+
+    const ctx = new SnackBarContext();
+    ctx.run(async () => {
+      ctx
+        .inject(MatSnackBar)
+        // When using the built-in TestBedHarnessEnvironment, fetching the harness would flush the duration and it would disappear before being selected
+        .open('Hello, snackbar!', 'OK', { duration: 5000 });
+      expect(await ctx.getHarness(MatSnackBarHarness)).toBeDefined();
+    });
+  });
+});

--- a/projects/ng-dev/src/lib/test-context/angular-context/fake-async-harness-environment-next.ts
+++ b/projects/ng-dev/src/lib/test-context/angular-context/fake-async-harness-environment-next.ts
@@ -2,18 +2,20 @@ import { HarnessEnvironment } from '@angular/cdk/testing';
 import { UnitTestElement } from '@angular/cdk/testing/testbed';
 import { flush } from '@angular/core/testing';
 import { bindKey } from '@s-libs/micro-dash';
-import { AngularContext } from './angular-context';
-import { synchronize, Synchronized } from '../synchronize';
+import { AngularContextNext } from './angular-context-next';
 
 /** @hidden */
-export class FakeAsyncHarnessEnvironment extends HarnessEnvironment<Element> {
+export class FakeAsyncHarnessEnvironmentNext extends HarnessEnvironment<Element> {
   static documentRootLoader(
-    ctx: AngularContext,
-  ): Synchronized<FakeAsyncHarnessEnvironment> {
-    return synchronize(new FakeAsyncHarnessEnvironment(document.body, ctx));
+    ctx: AngularContextNext,
+  ): FakeAsyncHarnessEnvironmentNext {
+    return new FakeAsyncHarnessEnvironmentNext(document.body, ctx);
   }
 
-  protected constructor(rawRootElement: Element, private ctx: AngularContext) {
+  protected constructor(
+    rawRootElement: Element,
+    private ctx: AngularContextNext,
+  ) {
     super(rawRootElement);
   }
 
@@ -26,7 +28,7 @@ export class FakeAsyncHarnessEnvironment extends HarnessEnvironment<Element> {
   }
 
   protected createEnvironment(element: Element): HarnessEnvironment<Element> {
-    return new FakeAsyncHarnessEnvironment(element, this.ctx);
+    return new FakeAsyncHarnessEnvironmentNext(element, this.ctx);
   }
 
   protected createTestElement(element: Element): UnitTestElement {

--- a/projects/ng-dev/src/lib/test-context/angular-context/fake-async-harness-environment.spec.ts
+++ b/projects/ng-dev/src/lib/test-context/angular-context/fake-async-harness-environment.spec.ts
@@ -1,7 +1,7 @@
 import { ContentContainerComponentHarness } from '@angular/cdk/testing';
 import { Component } from '@angular/core';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { ComponentContextNext } from '../component-context';
+import { ComponentContext } from '../component-context';
 import { Synchronized } from '../synchronize';
 
 @Component({
@@ -19,10 +19,14 @@ class WrapperHarness extends ContentContainerComponentHarness {
   static hostSelector = '.wrapper';
 }
 
+class TestContext extends ComponentContext {
+  protected componentType = TestComponent;
+}
+
 describe('FakeAsyncHarnessEnvironment', () => {
-  let ctx: ComponentContextNext<TestComponent>;
+  let ctx: TestContext;
   beforeEach(() => {
-    ctx = new ComponentContextNext(TestComponent);
+    ctx = new TestContext();
   });
 
   it('runs asynchronous events that are due automatically', () => {

--- a/projects/ng-dev/src/lib/test-context/angular-context/fake-async-harness-environment.ts
+++ b/projects/ng-dev/src/lib/test-context/angular-context/fake-async-harness-environment.ts
@@ -2,18 +2,20 @@ import { HarnessEnvironment } from '@angular/cdk/testing';
 import { UnitTestElement } from '@angular/cdk/testing/testbed';
 import { flush } from '@angular/core/testing';
 import { bindKey } from '@s-libs/micro-dash';
-import { AngularContext } from './angular-context';
 import { synchronize, Synchronized } from '../synchronize';
 
 /** @hidden */
 export class FakeAsyncHarnessEnvironment extends HarnessEnvironment<Element> {
-  static documentRootLoader(
-    ctx: AngularContext,
-  ): Synchronized<FakeAsyncHarnessEnvironment> {
+  static documentRootLoader(ctx: {
+    tick(): void;
+  }): Synchronized<FakeAsyncHarnessEnvironment> {
     return synchronize(new FakeAsyncHarnessEnvironment(document.body, ctx));
   }
 
-  protected constructor(rawRootElement: Element, private ctx: AngularContext) {
+  protected constructor(
+    rawRootElement: Element,
+    private ctx: { tick(): void },
+  ) {
     super(rawRootElement);
   }
 

--- a/projects/ng-dev/src/lib/test-context/angular-context/index.ts
+++ b/projects/ng-dev/src/lib/test-context/angular-context/index.ts
@@ -1,1 +1,2 @@
 export { AngularContext } from './angular-context';
+export { AngularContextNext } from './angular-context-next';

--- a/projects/ng-dev/src/lib/test-context/component-context/component-context-next.spec.ts
+++ b/projects/ng-dev/src/lib/test-context/component-context/component-context-next.spec.ts
@@ -94,11 +94,11 @@ describe('ComponentContextNext', () => {
     });
   });
 
-  describe('.updateInputs()', () => {
+  describe('.assignInputs()', () => {
     it('updates the inputs', () => {
       const ctx = new ComponentContextNext(TestComponent);
       ctx.run(() => {
-        ctx.updateInputs({ name: 'New Guy' });
+        ctx.assignInputs({ name: 'New Guy' });
         expect(ctx.fixture.nativeElement.textContent).toContain('New Guy');
       });
     });
@@ -108,7 +108,7 @@ describe('ComponentContextNext', () => {
       ctx.run(() => {
         const spy = ctx.getComponentInstance().ngOnChangesSpy;
         spy.calls.reset();
-        ctx.updateInputs({ myInput: 'new value' });
+        ctx.assignInputs({ myInput: 'new value' });
         expect(spy).toHaveBeenCalledTimes(1);
         const changes: SimpleChanges = spy.calls.mostRecent().args[0];
         expect(changes.myInput.currentValue).toBe('new value');
@@ -125,7 +125,7 @@ describe('ComponentContextNext', () => {
 
       const ctx = new ComponentContextNext(NonInputComponent);
       expect(() => {
-        ctx.updateInputs({ nonInput: 'value' });
+        ctx.assignInputs({ nonInput: 'value' });
       }).toThrowError(
         'Cannot bind to "nonInput" (it is not an input, or you passed it in `unboundProperties`)',
       );
@@ -140,7 +140,7 @@ describe('ComponentContextNext', () => {
         'doNotBind',
       ]);
       expect(() => {
-        ctx.updateInputs({ doNotBind: "I'll do what I want" });
+        ctx.assignInputs({ doNotBind: "I'll do what I want" });
       }).toThrowError(
         'Cannot bind to "doNotBind" (it is not an input, or you passed it in `unboundProperties`)',
       );
@@ -150,7 +150,7 @@ describe('ComponentContextNext', () => {
   describe('.getComponentInstance()', () => {
     it('returns the instantiated component', () => {
       const ctx = new ComponentContextNext(TestComponent);
-      ctx.updateInputs({ name: 'instantiated name' });
+      ctx.assignInputs({ name: 'instantiated name' });
       ctx.run(() => {
         expect(ctx.getComponentInstance().name).toBe('instantiated name');
       });
@@ -256,7 +256,7 @@ describe('ComponentContextNext class-level doc examples', () => {
 
     it('greets you by name', () => {
       const ctx = new ComponentContextNext(GreeterComponent);
-      ctx.updateInputs({ name: 'World' });
+      ctx.assignInputs({ name: 'World' });
       ctx.run(() => {
         expect(ctx.fixture.nativeElement.textContent).toBe('Hello, World!');
       });

--- a/projects/ng-dev/src/lib/test-context/component-context/component-context-next.spec.ts
+++ b/projects/ng-dev/src/lib/test-context/component-context/component-context-next.spec.ts
@@ -96,13 +96,6 @@ describe('ComponentContextNext', () => {
       });
     });
 
-    it('accepts component input', () => {
-      const ctx = new ComponentContextNext(TestComponent);
-      ctx.run({ inputs: { name: 'Default Guy' } }, () => {
-        expect(ctx.fixture.nativeElement.textContent).toContain('Default Guy');
-      });
-    });
-
     it('triggers ngOnChanges', () => {
       const ctx = new ComponentContextNext(ChangeDetectingComponent);
       ctx.run(() => {
@@ -115,7 +108,8 @@ describe('ComponentContextNext', () => {
   describe('.getComponentInstance()', () => {
     it('returns the instantiated component', () => {
       const ctx = new ComponentContextNext(TestComponent);
-      ctx.run({ inputs: { name: 'instantiated name' } }, () => {
+      ctx.updateInputs({ name: 'instantiated name' });
+      ctx.run(() => {
         expect(ctx.getComponentInstance().name).toBe('instantiated name');
       });
     });
@@ -205,7 +199,7 @@ describe('ComponentContextNext', () => {
         'doNotBind',
       ]);
       expect(() => {
-        ctx.run({ inputs: { doNotBind: "I'll do what I want" } }, noop);
+        ctx.updateInputs({ doNotBind: "I'll do what I want" });
       }).toThrowError(
         'Cannot bind to "doNotBind" (it is not an input, or you passed it in `unboundProperties`)',
       );
@@ -222,7 +216,8 @@ describe('ComponentContextNext class-level doc examples', () => {
 
     it('greets you by name', () => {
       const ctx = new ComponentContextNext(GreeterComponent);
-      ctx.run({ inputs: { name: 'World' } }, () => {
+      ctx.updateInputs({ name: 'World' });
+      ctx.run(() => {
         expect(ctx.fixture.nativeElement.textContent).toBe('Hello, World!');
       });
     });

--- a/projects/ng-dev/src/lib/test-context/component-context/component-context-next.spec.ts
+++ b/projects/ng-dev/src/lib/test-context/component-context/component-context-next.spec.ts
@@ -246,7 +246,6 @@ describe('ComponentContextNext', () => {
   });
 });
 
-// TODO: update this in the actual documentation
 describe('ComponentContextNext class-level doc examples', () => {
   describe('simple example', () => {
     @Component({ template: 'Hello, {{name}}!' })

--- a/projects/ng-dev/src/lib/test-context/component-context/component-context-next.ts
+++ b/projects/ng-dev/src/lib/test-context/component-context/component-context-next.ts
@@ -19,10 +19,11 @@ import { FakeAsyncHarnessEnvironmentNext } from '../angular-context/fake-async-h
 import { createDynamicWrapper } from './create-dynamic-wrapper';
 
 /**
- * A superclass to set up testing contexts for components. This is a foundation for an opinionated testing pattern, including everything described in {@link AngularContext} plus:
+ * A superclass to set up testing contexts for components. This is a foundation for an opinionated testing pattern, including everything described in {@link AngularContextNext} plus:
  *
  * - Automatically creates your component at the beginning of `run()`.
  * - Wraps your component in a dynamically created parent component. (This sets up Angular to call `ngOnChanges()` in your tests the same way it does in production.)
+ * - Lets you use {@link https://material.angular.io/cdk/test-harnesses/overview|component harnesses} (which are normally not usable within a `fakeAsync` test).
  * - Automatically disables animations.
  * - Automatically integrates {@link trimLeftoverStyles} to speed up your test suite.
  *
@@ -37,7 +38,8 @@ import { createDynamicWrapper } from './create-dynamic-wrapper';
  *
  * it('greets you by name', () => {
  *   const ctx = new ComponentContextNext(GreeterComponent);
- *   ctx.run({ inputs: { name: 'World' } }, () => {
+ *   ctx.assignInputs({ name: 'World' });
+ *   ctx.run(() => {
  *     expect(ctx.fixture.nativeElement.textContent).toBe('Hello, World!');
  *   });
  * });
@@ -156,7 +158,7 @@ export class ComponentContextNext<T> extends AngularContextNext {
 
   /**
    * @param componentType `run()` will create a component of this type before running the rest of your test.
-   * @param moduleMetadata passed along to [TestBed.configureTestingModule()]{@linkcode https://angular.io/api/core/testing/TestBed#configureTestingModule}. Automatically includes {@link NoopAnimationsModule}, in addition to those provided by {@link AngularContext}.
+   * @param moduleMetadata passed along to [TestBed.configureTestingModule()]{@linkcode https://angular.io/api/core/testing/TestBed#configureTestingModule}. Automatically includes {@link NoopAnimationsModule}, in addition to those provided by {@link AngularContextNext}.
    * @param unboundInputs By default a synthetic parent component will be created that binds to all your component's inputs. Pass input names here that should NOT be bound. This is useful e.g. to test the default value of an input.
    */
   constructor(
@@ -180,7 +182,7 @@ export class ComponentContextNext<T> extends AngularContextNext {
   /**
    * Use within `run()` to update the inputs to your component and trigger all the appropriate change detection and lifecycle hooks. Only the inputs specified in `inputs` will be affected.
    */
-  updateInputs(inputs: Partial<T>): void {
+  assignInputs(inputs: Partial<T>): void {
     for (const key of keys(inputs)) {
       if (!this.inputProperties.has(key as keyof T)) {
         throw new Error(

--- a/projects/ng-dev/src/lib/test-context/component-context/create-dynamic-wrapper.spec.ts
+++ b/projects/ng-dev/src/lib/test-context/component-context/create-dynamic-wrapper.spec.ts
@@ -44,7 +44,7 @@ describe('createDynamicWrapper()', () => {
     }
 
     const ctx = new ComponentContextNext(RenamedInputComponent);
-    ctx.updateInputs({ propertyName: 'custom value' });
+    ctx.assignInputs({ propertyName: 'custom value' });
     ctx.run(() => {
       expect(ctx.fixture.nativeElement.textContent).toContain('custom value');
     });
@@ -61,7 +61,7 @@ describe('createDynamicWrapper()', () => {
     }
 
     const ctx = new ComponentContextNext(SetterInputComponent);
-    ctx.updateInputs({ setterInput: 'sent value' });
+    ctx.assignInputs({ setterInput: 'sent value' });
     ctx.run(() => {
       expect(ctx.getComponentInstance().receivedValue).toBe('sent value');
     });
@@ -83,7 +83,7 @@ describe('createDynamicWrapper()', () => {
       @ViewChild('tricky') trickyChild!: ElementRef;
     }
     const ctx = new ComponentContextNext(TrickyViewChildComponent);
-    ctx.updateInputs({ tricky: 'the value' });
+    ctx.assignInputs({ tricky: 'the value' });
     ctx.run(() => {
       expect(ctx.getComponentInstance().tricky).toBe('the value');
     });

--- a/projects/ng-dev/src/lib/test-context/component-context/create-dynamic-wrapper.spec.ts
+++ b/projects/ng-dev/src/lib/test-context/component-context/create-dynamic-wrapper.spec.ts
@@ -44,7 +44,8 @@ describe('createDynamicWrapper()', () => {
     }
 
     const ctx = new ComponentContextNext(RenamedInputComponent);
-    ctx.run({ inputs: { propertyName: 'custom value' } }, () => {
+    ctx.updateInputs({ propertyName: 'custom value' });
+    ctx.run(() => {
       expect(ctx.fixture.nativeElement.textContent).toContain('custom value');
     });
   });
@@ -60,7 +61,8 @@ describe('createDynamicWrapper()', () => {
     }
 
     const ctx = new ComponentContextNext(SetterInputComponent);
-    ctx.run({ inputs: { setterInput: 'sent value' } }, () => {
+    ctx.updateInputs({ setterInput: 'sent value' });
+    ctx.run(() => {
       expect(ctx.getComponentInstance().receivedValue).toBe('sent value');
     });
   });
@@ -81,7 +83,8 @@ describe('createDynamicWrapper()', () => {
       @ViewChild('tricky') trickyChild!: ElementRef;
     }
     const ctx = new ComponentContextNext(TrickyViewChildComponent);
-    ctx.run({ inputs: { tricky: 'the value' } }, () => {
+    ctx.updateInputs({ tricky: 'the value' });
+    ctx.run(() => {
       expect(ctx.getComponentInstance().tricky).toBe('the value');
     });
   });

--- a/projects/ng-dev/src/lib/test-context/component-context/index.ts
+++ b/projects/ng-dev/src/lib/test-context/component-context/index.ts
@@ -1,5 +1,2 @@
 export { ComponentContext, ComponentContextInit } from './component-context';
-export {
-  ComponentContextNext,
-  ComponentContextNextInit,
-} from './component-context-next';
+export { ComponentContextNext } from './component-context-next';

--- a/projects/ng-dev/src/typing-tests/component-context-next.dts-spec.ts
+++ b/projects/ng-dev/src/typing-tests/component-context-next.dts-spec.ts
@@ -9,7 +9,7 @@ const ctx = new ComponentContextNext(TestComponent);
 // $ExpectType ComponentFixture<unknown>
 const fixture = ctx.fixture;
 // $ExpectType (inputs: Partial<TestComponent>) => void
-const updateInputs = ctx.updateInputs;
+const assignInputs = ctx.assignInputs;
 // $ExpectType TestComponent
 const componentInstance = ctx.getComponentInstance();
 

--- a/projects/ng-dev/src/typing-tests/component-context-next.dts-spec.ts
+++ b/projects/ng-dev/src/typing-tests/component-context-next.dts-spec.ts
@@ -1,7 +1,4 @@
-import {
-  ComponentContextNext,
-  ComponentContextNextInit,
-} from '../lib/test-context';
+import { ComponentContextNext } from '../lib/test-context';
 
 class TestComponent {}
 
@@ -12,12 +9,3 @@ const fixture = ctx.fixture;
 const assignInputs = ctx.assignInputs;
 // $ExpectType TestComponent
 const componentInstance = ctx.getComponentInstance();
-
-interface CustomInit extends ComponentContextNextInit<TestComponent> {
-  specialProperty: string;
-}
-const initedCtx = new ComponentContextNext<TestComponent, CustomInit>(
-  TestComponent,
-);
-// $ExpectType { (test: () => void): void; (options: Partial<CustomInit>, test: () => void): void; }
-const run = initedCtx.run;

--- a/projects/rxjs-core/package.json
+++ b/projects/rxjs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-libs/rxjs-core",
-  "version": "11.2.0-next.0",
+  "version": "11.2.0-next.1",
   "author": "Simonton Software",
   "license": "MIT",
   "homepage": "https://github.com/simontonsoftware/s-libs/tree/master/projects/rxjs-core",
@@ -10,8 +10,8 @@
     "directory": "projects/rxjs-core"
   },
   "peerDependencies": {
-    "@s-libs/js-core": "^11.2.0-next.0",
-    "@s-libs/micro-dash": "^11.2.0-next.0",
+    "@s-libs/js-core": "^11.2.0-next.1",
+    "@s-libs/micro-dash": "^11.2.0-next.1",
     "rxjs": "^6.6.0"
   },
   "dependencies": { "tslib": "^2.0.0" }


### PR DESCRIPTION
- Allow async/await tests in `ComponentContextNext`
- `ComponentContextNext.getHarness()` and `.getAllHarnesses()` now return harnesses that follow the standard asynchronous harness API
- Add `AngularContextNext`
